### PR TITLE
Support toggling message IDs on and off in chat view.

### DIFF
--- a/components/chat.go
+++ b/components/chat.go
@@ -14,17 +14,19 @@ import (
 
 // Chat is the definition of a Chat component
 type Chat struct {
-	List     *termui.List
-	Messages map[string]Message
-	Offset   int
+	List           *termui.List
+	Messages       map[string]Message
+	Offset         int
+	showMessageIDs bool
 }
 
 // CreateChatComponent is the constructor for the Chat struct
 func CreateChatComponent(inputHeight int) *Chat {
 	chat := &Chat{
-		List:     termui.NewList(),
-		Messages: make(map[string]Message),
-		Offset:   0,
+		List:           termui.NewList(),
+		Messages:       make(map[string]Message),
+		Offset:         0,
+		showMessageIDs: false,
 	}
 
 	chat.List.Height = termui.TermHeight() - inputHeight
@@ -195,20 +197,18 @@ func (c *Chat) AddReply(parentID string, message Message) {
 	}
 }
 
-// IsNewThread check whether a message that is going to be added as
-// a child to a parent message, is the first one or not
-func (c *Chat) IsNewThread(parentID string) bool {
-	if parent, ok := c.Messages[parentID]; ok {
-		if len(parent.Messages) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 // ClearMessages clear the c.Messages
 func (c *Chat) ClearMessages() {
 	c.Messages = make(map[string]Message)
+}
+
+// ToggleMessageIDs toggles the visibility of message IDs on and off in chat view
+func (c *Chat) ToggleMessageIDs() {
+	if c.showMessageIDs {
+		c.showMessageIDs = false
+	} else {
+		c.showMessageIDs = true
+	}
 }
 
 // ScrollUp will render the chat messages based on the Offset of the Chat
@@ -286,6 +286,13 @@ func (c *Chat) MessageToCells(msg Message) []termui.Cell {
 			msg.GetTime(),
 			termui.ColorDefault, termui.ColorDefault)...,
 		)
+
+		if c.showMessageIDs && msg.ThreadID == "" {
+			cells = append(cells, termui.DefaultTxBuilder.Build(
+				msg.GetMsgID(),
+				termui.ColorDefault, termui.ColorDefault)...,
+			)
+		}
 
 		// Thread
 		cells = append(cells, termui.DefaultTxBuilder.Build(

--- a/components/message.go
+++ b/components/message.go
@@ -22,6 +22,8 @@ var (
 
 type Message struct {
 	ID       string
+	MsgID    string
+	ThreadID string
 	Messages map[string]Message
 
 	Time    time.Time
@@ -48,6 +50,14 @@ func (m Message) GetTime() string {
 func (m Message) GetThread() string {
 	return fmt.Sprintf("[%s](%s)",
 		m.Thread,
+		m.StyleThread,
+	)
+}
+
+func (m Message) GetMsgID() string {
+	return fmt.Sprintf(
+		"[%s](%s) ",
+		m.MsgID,
 		m.StyleThread,
 	)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,7 @@ func getDefaultConfig() Config {
 				"<next>":     "chat-down",
 				"C-f":        "chat-down",
 				"C-d":        "chat-down",
+				"m":          "toggle-message-ids",
 				"n":          "channel-search-next",
 				"N":          "channel-search-prev",
 				"'":          "channel-jump",

--- a/handlers/event.go
+++ b/handlers/event.go
@@ -45,6 +45,7 @@ var actionMap = map[string]func(*context.AppContext){
 	"channel-search-next": actionSearchNextChannels,
 	"channel-search-prev": actionSearchPrevChannels,
 	"channel-jump":        actionJumpChannels,
+	"toggle-message-ids":  actionToggleMessageIDs,
 	"thread-up":           actionMoveCursorUpThreads,
 	"thread-down":         actionMoveCursorDownThreads,
 	"chat-up":             actionScrollUpChat,
@@ -154,7 +155,7 @@ func messageHandler(ctx *context.AppContext) {
 
 						// we (mis)use actionChangeChannel, to rerender, the
 						// view when a new thread has been started
-						if ctx.View.Chat.IsNewThread(threadTimestamp) {
+						if ctx.Service.IsNewThread(msg.ThreadID) {
 							actionChangeChannel(ctx)
 						} else {
 							termui.Render(ctx.View.Chat)
@@ -503,6 +504,12 @@ func actionSearchPrevChannels(ctx *context.AppContext) {
 
 func actionJumpChannels(ctx *context.AppContext) {
 	ctx.View.Channels.Jump()
+	actionChangeChannel(ctx)
+}
+
+func actionToggleMessageIDs(ctx *context.AppContext) {
+	ctx.View.Chat.ClearMessages()
+	ctx.View.Chat.ToggleMessageIDs()
 	actionChangeChannel(ctx)
 }
 


### PR DESCRIPTION
* This aids in creating new threads from old, unthreaded messages
* Paves the way for future slash commands, e.g. /delete, /edit, /emote


Please read [CONTRIBUTING.md](https://github.com/erroneousboat/slack-term/blob/master/CONTRIBUTING.md)